### PR TITLE
Refine local library install and compose startup flow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,7 @@
 .gitignore
 .vscode
 .mypy_cache
+.venv
 venv
 Dockerfile
 my_readme.txt
@@ -9,3 +10,5 @@ README.md
 logs
 adhoc_scripts
 *.bak
+.env
+secret

--- a/.gitignore
+++ b/.gitignore
@@ -120,4 +120,4 @@ adhoc_scripts
 generated.py
 market_data.bak
 settings.json
-my_readme.txt
+my_readme.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # market-data Agent Guide
 
-Last verified: 2026-03-22
+Last verified: 2026-03-23
 
 ## Scope
 - Applies to `market-data/` unless a deeper `AGENTS.md` overrides it.
@@ -14,13 +14,14 @@ Last verified: 2026-03-22
 ## Important Paths
 - `src/server/main.py`: FastAPI entry point and route definitions.
 - `src/job/stocks/`: stock scraping jobs.
-- `src/job/options/option_price/`: options scraping jobs.
+- `src/job/options/`: options scraping jobs.
 - `src/db/`: database startup and connection logic.
 - `src/config/config.py`: required Postgres environment variables.
 - `market_data_piccolo/`: schema and migration artifacts.
+- `my_readme.md`: local scratchpad of useful commands and workflows for this repo. Treat it as a helpful operator reference, not canonical source of truth; validate commands against the current code and docs before relying on them.
 
 ## Repo-Specific Rules
-- Verify imports and dependency wiring before changing behavior. `pyproject.toml` currently points `market-data-library` at a stale absolute macOS path.
+- Verify imports and dependency wiring before changing behavior. `pyproject.toml` currently pins `market-data-library` from git, while local workflows may also use the sibling `../market-data-library` repo.
 - Do not claim end-to-end runtime validation unless the database environment and library dependency path were both verified locally.
 - Prefer small, targeted fixes. This repo has legacy patterns, incomplete TODOs, and little automated test coverage.
 - If a change affects shared provider behavior, move or mirror the logic into `market-data-library/` instead of growing more duplicated scraper code here.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,75 +1,45 @@
-# Dockerfile - Configuration for building the market data application container
+# syntax=docker/dockerfile:1.7
 
-# Pull the official Python slim image as the base image
-# Using slim variant to reduce image size while keeping necessary tools
-FROM python:3.12-slim-bullseye as base
+FROM python:3.12-slim-bullseye AS base
 
-# Set the working directory inside the container
-# All subsequent commands will be executed in this directory
 WORKDIR /app
 
-# Set environment variables to disable Python bytecode generation and enable unbuffered output
-# PYTHONDONTWRITEBYTECODE: Prevents Python from writing .pyc files
-# PYTHONUNBUFFERED: Ensures Python output is sent straight to terminal (helps with logging)
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
 
-# Install system dependencies and Poetry in a single layer for optimization
-# - build-essential: Provides compilers and development tools for building packages
-# - curl: Used for downloading resources
-# - git: Required for cloning repositories
-# - openssh-client: Provides SSH utilities like ssh-keyscan
-# The symbolic link ensures Poetry is in the system PATH
-RUN apt update && apt install -y --no-install-recommends \
-    build-essential curl git openssh-client && \
-    curl -sSL https://install.python-poetry.org | python3 && \
-    ln -s /root/.local/bin/poetry /usr/local/bin/poetry && \
-    apt clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    git \
+    openssh-client && \
+    rm -rf /var/lib/apt/lists/*
 
-# Copy dependency files for Poetry to install dependencies
-# This is done before copying the rest of the app for better layer caching
-COPY pyproject.toml poetry.lock ./
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
 
-# Set up SSH for accessing private repositories
-# The known_hosts file is populated with GitHub's host key to avoid prompts
-RUN mkdir -p /root/.ssh && \
-    ssh-keyscan github.com >> /root/.ssh/known_hosts
+FROM base AS deps-local
 
-# Copy the private SSH key for accessing private repositories
-# The key is used to authenticate with private Git repositories
-COPY secret/id_rsa /root/.ssh/id_rsa
-RUN chmod 600 /root/.ssh/id_rsa
+# Local dev mode installs the sibling repo provided as a named build context.
+COPY --from=market_data_library / /opt/market-data-library
+RUN pip install --no-cache-dir /opt/market-data-library
 
-ARG MARKET_DATA_LIBRARY_TAG
-RUN if [ -z "$MARKET_DATA_LIBRARY_TAG" ]; then echo "MARKET_DATA_LIBRARY_TAG is required"; exit 1; fi
-RUN pip install git+ssh://git@github.com/hanchiang/market_data_api.git@$MARKET_DATA_LIBRARY_TAG && rm /root/.ssh/id_rsa
+FROM base AS deps-git
 
-# Install Python dependencies using Poetry without creating a virtual environment
-# virtualenvs.create false: Install packages directly in system Python
-# --no-root: Don't install the project itself as a package
-# The SSH key is removed immediately after dependencies are installed for security
-RUN poetry config virtualenvs.create false && \
-    poetry install --no-root && \
-    rm -rf /root/.ssh/id_rsa
+# Consumer-style builds can instead install the shared library from a git ref.
+ARG MARKET_DATA_LIBRARY_REF=1.0.0
+RUN --mount=type=ssh \
+    pip install --no-cache-dir \
+    "git+ssh://git@github.com/hanchiang/market_data_api.git@${MARKET_DATA_LIBRARY_REF}"
 
-# Copy the application code into the container
-# This is done after dependency installation to leverage Docker's build cache
+FROM deps-local AS dev-local
+
 COPY . .
+# Keep both the app and the sibling library importable for the local compose flow.
+ENV PYTHONPATH=/app:/opt/market-data-library
+CMD ["uvicorn", "--reload", "--host", "0.0.0.0", "--app-dir", "src/server", "main:app"]
 
-# Remove the secret directory to ensure no sensitive files remain in the image
-# This is a security best practice to avoid exposing credentials in the final image
-RUN rm -rf "$(pwd)/secret"
+FROM deps-git AS dev-git
 
-# Set the PYTHONPATH environment variable to include the current working directory
-# This ensures Python can find modules in the project
-ENV PYTHONPATH "${PYTHONPATH}:$(pwd)"
-
-# Use the base image to create a development image with Uvicorn as the entry point
-# This creates a separate target for development use
-FROM base as dev
-
-# Start the Uvicorn server with hot-reload for development
-# --reload: Enable auto-reload on code changes
-# --host 0.0.0.0: Allow connections from any IP
-# --app-dir: Specify the directory containing the app
+COPY . .
+ENV PYTHONPATH=/app
 CMD ["uvicorn", "--reload", "--host", "0.0.0.0", "--app-dir", "src/server", "main:app"]

--- a/README.md
+++ b/README.md
@@ -18,11 +18,58 @@ There are 2 parts to the project:
 * Install dependencies with Poetry: `poetry install --no-root`
   * `market-data-library` is resolved from the sibling directory `../market-data-library`
 * Set PYTHONPATH: `export PYTHONPATH=$(pwd)`
+* Run migrations before starting the app: `poetry run piccolo migrations forwards market_data_piccolo --trace`
 * Start server: `poetry run uvicorn --reload --app-dir src/server main:app`
   * Server runs at: `localhost:8000`
   * API documentation runs at: `localhost:8000/docs`, `localhost:8000/redoc`.
 * Legacy setup still exists for Docker and `requirements.txt`, but the tracked local development path is Poetry plus the sibling `market-data-library` repo.
-* Before using the API or scrapers, ensure Postgres is reachable and Piccolo can run migrations with the configured credentials.
+* Before using the API or scrapers, ensure Postgres is reachable and Piccolo migrations have already been applied with the configured credentials.
+
+# Run Modes
+* Dockerized DB, app running locally:
+  * Start only the database: `docker compose up -d db`
+  * In `.env`, set `POSTGRES_HOST=localhost`
+  * Run migrations locally: `poetry run piccolo migrations forwards market_data_piccolo --trace`
+  * Set `PYTHONPATH`: `export PYTHONPATH=$(pwd)`
+  * Start the app locally: `poetry run uvicorn --reload --app-dir src/server main:app`
+* Fully Dockerized app and DB:
+  * Use the compose workflow in the Docker section below
+
+# Docker
+* You can also start the full stack with `docker compose up -d`
+  * Compose will start `db`, run the one-shot `migrate` service, then start `backend`
+* Default local compose path uses the sibling `../market-data-library` repo:
+  * `docker compose up -d db`
+  * `docker compose run --rm migrate`
+  * `docker compose up backend`
+  * Inside compose, the backend and migration service connect to Postgres with `POSTGRES_HOST=db`
+* For consumer-style testing against a git-installed `market-data-library`, build the alternate target:
+  * `DOCKER_BUILDKIT=1 docker build --target dev-git --ssh default --build-arg MARKET_DATA_LIBRARY_REF=1.0.0 -t market-data:dev-git .`
+  * This Git validation path requires SSH access to the private GitHub repository.
+
+# Operations
+* Piccolo migration status check:
+  * `poetry run piccolo migrations check`
+* Create a new Piccolo migration:
+  * `poetry run piccolo migrations new market_data_piccolo`
+* Apply migrations locally:
+  * `poetry run piccolo migrations forwards market_data_piccolo --trace`
+* Apply migrations in Docker:
+  * `docker compose run --rm migrate`
+* Roll back migrations locally:
+  * `poetry run piccolo migrations backwards market_data_piccolo --trace`
+* Roll back all migrations locally:
+  * `poetry run piccolo migrations backwards market_data_piccolo --migration_id=all --trace --auto_agree`
+* Show compose service status:
+  * `docker compose ps`
+* Show compose logs:
+  * `docker compose logs --tail 100 backend migrate db`
+* Stop the Dockerized stack:
+  * `docker compose down`
+* Run the options scraper locally:
+  * `poetry run python src/job/options/scraper.py`
+* Run the stocks scraper locally:
+  * `poetry run python src/job/stocks/scraper.py`
 
 # Tech stack
 * Language: Python

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,38 +1,81 @@
-version: '3.8'
-
 services:
-  backend:
-    build:
-        context: .
-        target: dev
-        dockerfile: Dockerfile
-    image: market-data:dev
-    container_name: backend
-    command: uvicorn --reload --app-dir src/server --host 0.0.0.0 main:app
-    depends_on:
-      - db
-    environment:
-      POSTGRES_HOST: db
-      POSTGRES_DB: market_data
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: root
-      POSTGRES_PORT: 5432
-    volumes:
-      - .:/app
-      - /app/secret
-      - /app/venv
-    ports:
-      - 8000:8000
   db:
     image: timescale/timescaledb-ha:pg14-latest
     container_name: db
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: root
-      POSTGRES_DB: market_data
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-change-me}
+      POSTGRES_DB: ${POSTGRES_DB:-market_data}
     volumes:
       - db-volume:/home/postgres/pgdata/data
     ports:
       - 5432:5432
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-market_data}",
+        ]
+      # Backend and migrations wait on DB health so cold starts don't race Postgres.
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 5s
+
+  migrate:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: dev-local
+      additional_contexts:
+        market_data_library: ../market-data-library
+    image: market-data:migrate
+    container_name: migrate
+    # Run schema setup once per compose startup; backend won't start unless this succeeds.
+    command: piccolo migrations forwards market_data_piccolo --trace
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      # Inside compose, services talk to the DB over the service name, not localhost.
+      POSTGRES_HOST: db
+      POSTGRES_DB: ${POSTGRES_DB:-market_data}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-change-me}
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+    volumes:
+      - .:/app
+      - ../market-data-library:/opt/market-data-library
+    restart: "no"
+
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: dev-local
+      additional_contexts:
+        market_data_library: ../market-data-library
+    image: market-data:dev-local
+    container_name: backend
+    command: uvicorn --reload --app-dir src/server --host 0.0.0.0 main:app
+    depends_on:
+      db:
+        condition: service_healthy
+      migrate:
+        # Fail fast if migrations don't apply cleanly.
+        condition: service_completed_successfully
+    environment:
+      # Inside compose, services talk to the DB over the service name, not localhost.
+      POSTGRES_HOST: db
+      POSTGRES_DB: ${POSTGRES_DB:-market_data}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-change-me}
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+    volumes:
+      - .:/app
+      - ../market-data-library:/opt/market-data-library
+    ports:
+      - 8000:8000
+
 volumes:
   db-volume:

--- a/poetry.lock
+++ b/poetry.lock
@@ -820,10 +820,8 @@ selenium-stealth = "^1.0.6"
 tenacity = "^9.1.2"
 
 [package.source]
-type = "git"
-url = "ssh://git@github.com/hanchiang/market_data_api.git"
-reference = "1.0.0"
-resolved_reference = "dd76f6e6a93dcd8d86f655bb3b05c4c53c3c9231"
+type = "directory"
+url = "../market-data-library"
 
 [[package]]
 name = "markupsafe"
@@ -1861,4 +1859,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.14"
-content-hash = "68c675c7e151068e7084062aaa637a55db255ea547e20aaf959c465b756560b1"
+content-hash = "6017b2b113ee827a296e9b25c0ddcfe82f049bc06eba1617a0492446b27ac283"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ uvicorn = "0.19.0"
 python-dotenv = "0.21.0"
 asyncio-tools = "1.0.0"
 httpx = "^0.28.1"
-market-data-library = {git = "ssh://git@github.com/hanchiang/market_data_api.git", rev = "1.0.0"}
+market-data-library = {path = "../market-data-library", develop = false}
 
 
 [tool.poetry.group.dev.dependencies]

--- a/src/db/index.py
+++ b/src/db/index.py
@@ -1,19 +1,6 @@
-import asyncio
 import multiprocessing
-import os
-import subprocess
 
 from piccolo.engine import engine_finder
-
-async def run_migration():
-    print('Running postgres migration scripts. Wait 1 seconds for timescale db to be ready')
-    await asyncio.sleep(1)
-    result = subprocess.run('piccolo migrations forwards market_data_piccolo --trace', cwd=os.getcwd(), timeout=300,
-                            shell=True, capture_output=True)
-    print(result)
-    print(f'stdout: {result.stdout}')
-    if result.stderr:
-        print(f'stderr: {result.stderr}')
 
 async def start_postgres_connection_pool():
     engine = engine_finder()

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -4,8 +4,7 @@ from typing import Optional
 from src.market_data_library_adapter import serialize_payload
 from market_data_library.core.tradfi.api import BarchartAPI
 
-from src.db.index import run_migration, start_postgres_connection_pool, stop_postgres_connection_pool
-from src.data_source.barchart import get_tradfi_api, init_tradfi_api
+from src.db.index import start_postgres_connection_pool, stop_postgres_connection_pool
 
 app = FastAPI()
 
@@ -23,8 +22,6 @@ async def startup_event():
     print('FastAPI startup event')
     barchart = BarchartAPI()
     await start_postgres_connection_pool()
-    await run_migration()
-    init_tradfi_api()
 
 @app.on_event('shutdown')
 async def shutdown_event():


### PR DESCRIPTION
## Summary
- switch the default `market-data-library` dependency to the sibling `../market-data-library` repo for local installs
- rework the Docker and compose setup so local dev uses a `dev-local` target plus a one-shot migration service
- stop running migrations during FastAPI startup and document the updated local and Docker workflows

## Validation
- `poetry lock`
- `poetry install --no-root`
- `poetry run python -m py_compile $(rg --files -g '*.py')`
- `poetry show market-data-library`
- `poetry run python -c 'import market_data_library, sys; print(market_data_library.__file__); print(sys.version)'`

## Notes
- keeps a separate `dev-git` Docker target for consumer-style validation against a git-installed `market-data-library`
- branch includes the current repo-local Docker, compose, README, and startup cleanup changes already present in the working tree